### PR TITLE
feat: obfuscate phone number in registration using Base64 encoding

### DIFF
--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -47,11 +47,17 @@ const Register = () => {
 
   const onRegister = async (values) => {
     try {
+      const encodePhoneNumber = (phoneNumber) => {
+        return btoa(phoneNumber); // base64 encode
+      };
+      const encodedPhoneNumber = encodePhoneNumber(values.phoneNumber);
+
       const encryptedPassword = CryptoJS.SHA256(values.password).toString(
         CryptoJS.enc.Hex
       );
       const registrationData = {
         ...values,
+        phoneNumber: encodedPhoneNumber,
         password: encryptedPassword,
       };
       const response = await fetch(`${baseURL}/auth/register`, {

--- a/server/routes/jwtAuth.js
+++ b/server/routes/jwtAuth.js
@@ -40,10 +40,15 @@ router.post("/register", validInfo, async (req, res) => {
       email,
     ]);
 
+    // decode phone number from base64
+    const decodedPhoneNumber = Buffer.from(phoneNumber, "base64").toString(
+      "utf-8"
+    );
+
     // check if phone number exists
     const phoneExist = await pool.query(
       "SELECT * FROM users WHERE phone_number = $1",
-      [phoneNumber]
+      [decodedPhoneNumber]
     );
 
     if (user.rows.length !== 0) {
@@ -65,7 +70,7 @@ router.post("/register", validInfo, async (req, res) => {
     const newUser = await pool.query(
       `INSERT INTO users(name, user_type, email, password, phone_number, method)
        VALUES($1, $2, $3, $4, $5, $6) RETURNING *`,
-      [name, "parent", email, bcryptedPassword, phoneNumber, "email"]
+      [name, "parent", email, bcryptedPassword, decodedPhoneNumber, "email"]
     );
 
     if (newUser) {


### PR DESCRIPTION
### What does this PR do?
- Implements Base64 encoding for phone numbers in the registration process to prevent them from appearing in the network tab.
- Ensures that the backend still receives the correct phone number by decoding it.

### Why is this needed?
- This is a frontend obfuscation method to hide phone numbers in network requests.
- Helps prevent users from directly seeing their phone numbers in DevTools.

### How does it work?
- The frontend **Base64 encodes** the phone number before sending it via API.
- The backend **Base64 decodes** it before storing it in the database.
- No impact on backend logic, just an added layer to improve frontend data handling.

### How can this be tested?
1. Open DevTools (`F12`) → Go to the **Network** tab.
2. Fill in the registration form with a phone number.
3. Submit the form and inspect the request payload.
4. The `phoneNumber` field should now be **Base64 encoded** instead of plaintext.
5. Confirm that the backend correctly receives and processes the original number.
