### PR TITLE
feat: initial child schedule display (draft)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,9 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
+        "@fullcalendar/core": "^6.1.15",
+        "@fullcalendar/react": "^6.1.15",
+        "@fullcalendar/timegrid": "^6.1.15",
         "@react-oauth/google": "^0.12.1",
         "@splidejs/react-splide": "^0.7.12",
         "@splidejs/splide-extension-grid": "^0.4.1",
@@ -2169,6 +2172,43 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "node_modules/@fullcalendar/core": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.15.tgz",
+      "integrity": "sha512-BuX7o6ALpLb84cMw1FCB9/cSgF4JbVO894cjJZ6kP74jzbUZNjtwffwRdA+Id8rrLjT30d/7TrkW90k4zbXB5Q==",
+      "dependencies": {
+        "preact": "~10.12.1"
+      }
+    },
+    "node_modules/@fullcalendar/daygrid": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
+      "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15"
+      }
+    },
+    "node_modules/@fullcalendar/react": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.15.tgz",
+      "integrity": "sha512-L0b9hybS2J4e7lq6G2CD4nqriyLEqOH1tE8iI6JQjAMTVh5JicOo5Mqw+fhU5bJ7hLfMw2K3fksxX3Ul1ssw5w==",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15",
+        "react": "^16.7.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@fullcalendar/timegrid": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.15.tgz",
+      "integrity": "sha512-61ORr3A148RtxQ2FNG7JKvacyA/TEVZ7z6I+3E9Oeu3dqTf6M928bFcpehRTIK6zIA6Yifs7BeWHgOE9dFnpbw==",
+      "dependencies": {
+        "@fullcalendar/daygrid": "~6.1.15"
+      },
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.15"
+      }
     },
     "node_modules/@hapi/address": {
       "version": "2.1.4",
@@ -15105,6 +15145,15 @@
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
     },
+    "node_modules/preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -21974,6 +22023,32 @@
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@fullcalendar/core": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.15.tgz",
+      "integrity": "sha512-BuX7o6ALpLb84cMw1FCB9/cSgF4JbVO894cjJZ6kP74jzbUZNjtwffwRdA+Id8rrLjT30d/7TrkW90k4zbXB5Q==",
+      "requires": {
+        "preact": "~10.12.1"
+      }
+    },
+    "@fullcalendar/daygrid": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.15.tgz",
+      "integrity": "sha512-j8tL0HhfiVsdtOCLfzK2J0RtSkiad3BYYemwQKq512cx6btz6ZZ2RNc/hVnIxluuWFyvx5sXZwoeTJsFSFTEFA=="
+    },
+    "@fullcalendar/react": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.15.tgz",
+      "integrity": "sha512-L0b9hybS2J4e7lq6G2CD4nqriyLEqOH1tE8iI6JQjAMTVh5JicOo5Mqw+fhU5bJ7hLfMw2K3fksxX3Ul1ssw5w=="
+    },
+    "@fullcalendar/timegrid": {
+      "version": "6.1.15",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.15.tgz",
+      "integrity": "sha512-61ORr3A148RtxQ2FNG7JKvacyA/TEVZ7z6I+3E9Oeu3dqTf6M928bFcpehRTIK6zIA6Yifs7BeWHgOE9dFnpbw==",
+      "requires": {
+        "@fullcalendar/daygrid": "~6.1.15"
+      }
     },
     "@hapi/address": {
       "version": "2.1.4",
@@ -32208,6 +32283,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
+    "preact": {
+      "version": "10.12.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
+      "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
+    "@fullcalendar/timegrid": "^6.1.15",
     "@react-oauth/google": "^0.12.1",
     "@splidejs/react-splide": "^0.7.12",
     "@splidejs/splide-extension-grid": "^0.4.1",

--- a/client/src/components/Profile/Child.css
+++ b/client/src/components/Profile/Child.css
@@ -1,37 +1,52 @@
-/* Default event background (dark pink) */
-.fc-event {
+/* Unified event styling for both timeGrid and dayGrid views */
+.fc-event,
+.fc-daygrid-event {
   background-color: #ed8294 !important;
   border: none !important;
   color: white !important;
   border-radius: 6px;
-  padding: 5px;
-  font-weight: bold;
+  padding: 2px;
 }
 
-/* Style all FullCalendar buttons */
+/* Remove bold from event title in Month view */
+.fc-event-title {
+  font-weight: normal !important;
+  color: white;
+}
+
+/* FullCalendar toolbar buttons */
 .fc .fc-button {
   background-color: #ed8294 !important;
   border-color: #ed8294 !important;
   color: #fff !important;
-  font-weight: bold;
+  font-weight: normal;
   text-transform: capitalize;
 }
 
-/* Hover effect */
 .fc .fc-button:hover {
-  background-color: #d46b7e !important; /* Slightly darker pink */
+  background-color: #d46b7e !important;
   border-color: #d46b7e !important;
 }
 
-/* Highlight the active (selected) button */
 .fc .fc-button.fc-button-active {
-  background-color: #d46b7e !important; /* Slightly darker pink when selected */
+  background-color: #d46b7e !important;
   border-color: #d46b7e !important;
   color: white !important;
 }
 
-/* Style the FullCalendar title (date range text) */
+/* Toolbar title (e.g., "May 2025") */
 .fc .fc-toolbar-title {
   color: #000 !important;
-  font-weight: bold;
+  font-weight: normal;
+}
+
+/* Adjust slot height in timeGrid (week view) */
+.fc-timegrid-slot {
+  height: 45px !important;
+}
+
+/* Calendar container layout */
+.calendar-wrapper {
+  height: calc(100vh - 130px);
+  overflow: hidden;
 }

--- a/client/src/components/Profile/Child.css
+++ b/client/src/components/Profile/Child.css
@@ -1,0 +1,37 @@
+/* Default event background (dark pink) */
+.fc-event {
+  background-color: #ed8294 !important;
+  border: none !important;
+  color: white !important;
+  border-radius: 6px;
+  padding: 5px;
+  font-weight: bold;
+}
+
+/* Style all FullCalendar buttons */
+.fc .fc-button {
+  background-color: #ed8294 !important;
+  border-color: #ed8294 !important;
+  color: #fff !important;
+  font-weight: bold;
+  text-transform: capitalize;
+}
+
+/* Hover effect */
+.fc .fc-button:hover {
+  background-color: #d46b7e !important; /* Slightly darker pink */
+  border-color: #d46b7e !important;
+}
+
+/* Highlight the active (selected) button */
+.fc .fc-button.fc-button-active {
+  background-color: #d46b7e !important; /* Slightly darker pink when selected */
+  border-color: #d46b7e !important;
+  color: white !important;
+}
+
+/* Style the FullCalendar title (date range text) */
+.fc .fc-toolbar-title {
+  color: #000 !important;
+  font-weight: bold;
+}

--- a/client/src/layouts/LoggedInLayout.js
+++ b/client/src/layouts/LoggedInLayout.js
@@ -233,7 +233,7 @@ const LoggedInLayout = () => {
     >
       <Layout
         style={{
-          height: "100vh",
+          minHeight: "100vh",
         }}
       >
         <HeaderConfig />

--- a/server/routes/children.js
+++ b/server/routes/children.js
@@ -49,21 +49,27 @@ router.get("/:child_id/schedule", async (req, res) => {
     const { child_id } = req.params;
 
     const childSchedule = await pool.query(
-      `SELECT 
-        c.child_id, 
-        c.name AS child_name,
-        l.listing_id, 
-        l.listing_title, 
-        s.day, 
-        s.timeslot AS class_time,  
-        o.address::json->>'POSTAL' AS postal_code 
+      `
+      SELECT
+        s.day,
+        s.timeslot               AS class_time,
+        l.listing_title,
+        l.active,
+        regexp_replace(
+          o.address,
+          '.*(\\d{6}).*',
+          '\\1'
+        )                       AS postal_code
       FROM transactions t
-      JOIN children c ON t.child_id = c.child_id
-      JOIN listings l ON t.listing_id = l.listing_id
-      JOIN outlets o ON l.listing_id = o.listing_id
-      JOIN schedules s ON o.outlet_id = s.outlet_id
+      JOIN children c            ON t.child_id = c.child_id
+      JOIN listings l            ON t.listing_id = l.listing_id
+      JOIN listingOutlets lo     ON lo.listing_id = l.listing_id
+      JOIN outlets o             ON lo.outlet_id = o.outlet_id
+      JOIN schedules s           ON lo.listing_outlet_id = s.listing_outlet_id
       WHERE c.child_id = $1
-      ORDER BY s.day;`,
+        AND l.active   = TRUE
+      ORDER BY s.day;
+      `,
       [child_id]
     );
 


### PR DESCRIPTION
## feat: initial child schedule display (draft)

### What does this PR do?  
This PR introduces an initial version of the child’s weekly schedule display. Parents can select a child profile to view their classes for the week or month

### Changes Introduced  
- Added a dropdown to select child profile.  
- Displays class title & postal code.  
- Uses FullCalendar to render schedule.  
- Fetches child schedule data from API.  

### Pending  
- Awaiting final decision on additional details to display.  
- UI/UX improvements based on feedback.  
- **More testing will be done after finalizing the details** (currently tested with two sample classes assigned to a child profile).  


### How to Test 
1. Log in and go to **Children** tab
2. Select a child from the dropdown.  
3. Verify that the calendar updates with the child's classes.  
