### PR TITLE
feat: refactor registration flow into two pages (Register & Verify OTP)

### DIFF
--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -6,191 +6,84 @@ import {
   MailOutlined,
   EyeTwoTone,
   EyeInvisibleOutlined,
-  NumberOutlined,
 } from "@ant-design/icons";
 import { Button, Form, Input, Typography, Divider } from "antd";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
 import { GoogleLogin } from "@react-oauth/google";
 import getBaseURL from "../utils/config";
-import useHandleLogin from "../hooks/useHandleLogin";
-import { useUserContext } from "./UserContext";
-import CryptoJS from "crypto-js";
 
 const { Title, Text } = Typography;
 
 const Register = () => {
   const baseURL = getBaseURL();
   const [registerForm] = Form.useForm();
-  const [otpSent, setOtpSent] = useState(false);
   const [isSendingOTP, setIsSendingOTP] = useState(false);
   const [isEmailValid, setIsEmailValid] = useState(false);
   const [isEmailDuplicate, setIsEmailDuplicate] = useState(false);
-  const [otpStep, setOtpStep] = useState("send"); // "send" or "verify"
-  const [cooldown, setCooldown] = useState(0);
-  const { from } = { from: { pathname: "/" } };
-  const { handleGoogleLogin } = useHandleLogin({ from });
-  const { setAuth } = useUserContext();
+  const navigate = useNavigate();
 
-  const startCooldown = () => {
-    let time = 60;
-    setCooldown(time);
+  const onNext = async (values) => {
+    if (!isEmailValid) {
+      toast.error("Please enter a valid email.");
+      return;
+    }
 
-    const interval = setInterval(() => {
-      time -= 1;
-      setCooldown(time);
-      if (time === 0) {
-        clearInterval(interval);
-      }
-    }, 1000);
-  };
-
-  const onRegister = async (values) => {
+    setIsSendingOTP(true);
     try {
-      const encryptedPassword = CryptoJS.SHA256(values.password).toString(
-        CryptoJS.enc.Hex
-      );
-      const registrationData = {
-        ...values,
-        password: encryptedPassword,
-      };
-      const response = await fetch(`${baseURL}/auth/register`, {
+      const email = values.email;
+
+      // Check if email is already registered
+      const checkEmailResponse = await fetch(`${baseURL}/auth/check-email`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      const checkEmailData = await checkEmailResponse.json();
+
+      if (!checkEmailResponse.ok || !checkEmailData.available) {
+        setIsEmailDuplicate(true);
+        setIsSendingOTP(false);
+        toast.error(
+          checkEmailData.message || "This email is already registered."
+        );
+        return;
+      }
+
+      setIsEmailDuplicate(false);
+
+      // Send OTP
+      const sendOTPResponse = await fetch(`${baseURL}/auth/send-otp`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(registrationData),
+        body: JSON.stringify({ email }),
       });
 
-      const parseRes = await response.json();
-      if (parseRes.token) {
-        localStorage.setItem("token", parseRes.token);
-        setAuth(true);
-        toast.success("Register successfully");
+      const parseRes = await sendOTPResponse.json();
+      if (sendOTPResponse.ok) {
+        toast.success(parseRes.message || "OTP sent successfully");
+        navigate("/verify-otp", { state: { email, ...values } });
       } else {
-        setAuth(false);
-        toast.error(parseRes.message);
+        throw new Error(
+          parseRes.message || "Failed to send OTP. Please try again."
+        );
       }
     } catch (error) {
-      setAuth(false);
-      console.error(error.message);
-      toast.error(error.message);
+      toast.error("Failed to send OTP. Please try again.");
+    } finally {
+      setIsSendingOTP(false);
     }
   };
 
-  const errorMessage = (error) => {
-    console.error(error);
-  };
-
-  // Handler to track phone number validation status
   const onFormValuesChange = (changedValues) => {
     if (changedValues.email) {
       const email = changedValues.email;
       const emailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
       setIsEmailValid(emailValid);
-
-      // Reset duplicate email state on input change
       setIsEmailDuplicate(false);
-    }
-  };
-
-  const handleSendOrVerifyOTP = async () => {
-    if (cooldown > 0) {
-      toast.error(`Please wait ${cooldown} seconds before trying again.`);
-      return;
-    }
-
-    if (otpStep === "send") {
-      // Handle sending OTP
-      if (!isEmailValid) {
-        toast.error("Please enter a valid email before requesting OTP.");
-        return;
-      }
-
-      setIsSendingOTP(true);
-      try {
-        const email = registerForm.getFieldValue("email");
-
-        // Check email availability
-        const checkEmailResponse = await fetch(`${baseURL}/auth/check-email`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email }),
-        });
-
-        const checkEmailData = await checkEmailResponse.json();
-
-        // Handle case where the email is already registered
-        if (!checkEmailResponse.ok || !checkEmailData.available) {
-          setIsEmailDuplicate(true);
-          setIsSendingOTP(false); // Stop sending OTP when email is already taken
-          toast.error(
-            checkEmailData.message || "This email is already registered."
-          );
-          return; // Early return to stop OTP sending
-        } else {
-          setIsEmailDuplicate(false);
-        }
-
-        // Start cooldown after email is valid and available
-        startCooldown();
-
-        // Send email OTP
-        const sendOTPResponse = await fetch(`${baseURL}/auth/send-otp`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ email }),
-        });
-
-        const parseRes = await sendOTPResponse.json();
-        if (sendOTPResponse.ok) {
-          setOtpSent(true);
-          setOtpStep("verify");
-          toast.success(parseRes.message || "OTP sent successfully");
-        } else {
-          throw new Error(
-            parseRes.message || "Failed to send OTP. Please try again."
-          );
-        }
-      } catch (error) {
-        console.error("Failed to send OTP. Please try again.");
-        toast.error("Failed to send OTP. Please try again.");
-        setOtpSent(false);
-      } finally {
-        setIsSendingOTP(false);
-      }
-    } else if (otpStep === "verify") {
-      // Handle verifying OTP
-      try {
-        console.log("Form values: ", registerForm.getFieldsValue());
-        const email = registerForm.getFieldValue("email");
-        const otp = registerForm.getFieldValue("otp");
-        console.log({ email, otp });
-
-        const verifyOTPResponse = await fetch(`${baseURL}/auth/verify-otp`, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ email, otp }),
-        });
-
-        const parseRes = await verifyOTPResponse.json();
-        if (verifyOTPResponse.ok) {
-          toast.success(parseRes.message || "OTP verified successfully");
-          setOtpSent("verified");
-        } else {
-          throw new Error(
-            parseRes.message || "Failed to verify OTP. Please try again."
-          );
-        }
-      } catch (error) {
-        console.error("Failed to verify OTP. Please try again.");
-        toast.error("Failed to verify OTP. Please try again.");
-        setOtpSent(false);
-      }
     }
   };
 
@@ -213,6 +106,7 @@ const Register = () => {
           background: "#ffffff",
           display: "flex",
           flexDirection: "column",
+          alignItems: "center",
           gap: "15px",
         }}
       >
@@ -220,46 +114,33 @@ const Register = () => {
           Register
         </Title>
         <GoogleLogin
-          onSuccess={handleGoogleLogin}
-          onError={errorMessage}
+          onSuccess={() => {}}
+          onError={() => {}}
           theme="outline"
-          width="345"
+          width="290"
         />
 
         <Divider>OR</Divider>
+
         <Form
           name="register"
           form={registerForm}
           className="register-form"
-          style={{
-            maxWidth: "100%",
-            margin: "0 auto",
-          }}
-          onFinish={onRegister}
+          style={{ maxWidth: "100%", margin: "0 auto", width: "290px" }} // width same as Google sign-in
+          onFinish={onNext}
           onValuesChange={onFormValuesChange}
         >
           <Form.Item
             name="name"
-            rules={[
-              {
-                required: true,
-                message: "Please input your name!",
-              },
-            ]}
+            rules={[{ required: true, message: "Please input your name!" }]}
           >
-            <Input
-              prefix={<UserOutlined className="site-form-item-icon" />}
-              placeholder="Name"
-              size={"large"}
-            />
+            <Input prefix={<UserOutlined />} placeholder="Name" size="large" />
           </Form.Item>
+
           <Form.Item
             name="phoneNumber"
             rules={[
-              {
-                required: true,
-                message: "Please input your phone number!",
-              },
+              { required: true, message: "Please input your phone number!" },
               {
                 pattern: /^[689]\d{7}$/,
                 message: "Phone number is in an invalid format!",
@@ -267,101 +148,38 @@ const Register = () => {
             ]}
           >
             <Input
-              prefix={<PhoneOutlined className="site-form-item-icon" />}
+              prefix={<PhoneOutlined />}
               placeholder="Phone Number"
-              size={"large"}
+              size="large"
             />
           </Form.Item>
 
           <Form.Item
             name="email"
-            rules={[
-              {
-                required: true,
-                message: "Please input your email!",
-              },
-            ]}
+            rules={[{ required: true, message: "Please input your email!" }]}
             help={isEmailDuplicate && "This email is already registered."}
             validateStatus={isEmailDuplicate ? "error" : ""}
           >
-            <div style={{ display: "flex", gap: "8px" }}>
-              <Input
-                prefix={<MailOutlined className="site-form-item-icon" />}
-                type={"email"}
-                placeholder="Email"
-                size={"large"}
-                style={{ flex: 1 }}
-                required
-              />
-              <Button
-                type="primary"
-                onClick={handleSendOrVerifyOTP}
-                disabled={
-                  !isEmailValid ||
-                  isEmailDuplicate ||
-                  cooldown > 0 ||
-                  isSendingOTP
-                }
-                loading={isSendingOTP}
-                size={"large"}
-                style={{ flex: 0.7, minWidth: "60px" }}
-              >
-                {isSendingOTP
-                  ? "Sending OTP..."
-                  : cooldown > 0
-                  ? `Resend OTP in ${cooldown}s`
-                  : "Send OTP"}
-              </Button>
-            </div>
-          </Form.Item>
-
-          <Form.Item
-            name="otp"
-            rules={[
-              {
-                required: otpStep !== "send",
-                message: "Please enter the OTP!",
-              },
-            ]}
-          >
-            <div style={{ display: "flex", gap: "8px" }}>
-              <Input
-                style={{ flex: 1 }}
-                placeholder="Enter the OTP"
-                disabled={!otpSent || otpStep === "send"}
-                size={"large"}
-                prefix={<NumberOutlined className="site-form-item-icon" />}
-              />
-              <Button
-                type="primary"
-                onClick={handleSendOrVerifyOTP}
-                disabled={!otpSent || otpStep === "send"}
-                size={"middle"}
-                style={{ flex: 0.7, minWidth: "60px" }}
-              >
-                Verify OTP
-              </Button>
-            </div>
+            <Input
+              prefix={<MailOutlined />}
+              type="email"
+              placeholder="Email"
+              size="large"
+            />
           </Form.Item>
 
           <Form.Item
             name="password"
-            rules={[
-              {
-                required: true,
-                message: "Please input your password!",
-              },
-            ]}
+            rules={[{ required: true, message: "Please input your password!" }]}
           >
             <Input.Password
-              prefix={<LockOutlined className="site-form-item-icon" />}
+              prefix={<LockOutlined />}
               type="password"
               placeholder="Password"
               size="large"
               iconRender={(visible) =>
                 visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
               }
-              required
             />
           </Form.Item>
 
@@ -369,10 +187,7 @@ const Register = () => {
             name="confirmPassword"
             dependencies={["password"]}
             rules={[
-              {
-                required: true,
-                message: "Please confirm your password!",
-              },
+              { required: true, message: "Please confirm your password!" },
               ({ getFieldValue }) => ({
                 validator(_, value) {
                   if (!value || getFieldValue("password") === value) {
@@ -386,14 +201,13 @@ const Register = () => {
             ]}
           >
             <Input.Password
-              prefix={<LockOutlined className="site-form-item-icon" />}
+              prefix={<LockOutlined />}
               type="password"
               placeholder="Confirm Password"
               size="large"
               iconRender={(visible) =>
                 visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
               }
-              required
             />
           </Form.Item>
 
@@ -401,16 +215,14 @@ const Register = () => {
             <Button
               type="primary"
               htmlType="submit"
-              className="login-form-button"
+              className="next-button"
               style={{ width: "100%" }}
+              loading={isSendingOTP}
+              disabled={isSendingOTP || isEmailDuplicate}
             >
-              Register
+              Next
             </Button>
-            <div
-              style={{
-                textAlign: "center",
-              }}
-            >
+            <div style={{ textAlign: "center" }}>
               <Text>Already have an account? </Text>
               <Link to="/login">Login</Link>
             </div>

--- a/client/src/components/VerifyOTP.js
+++ b/client/src/components/VerifyOTP.js
@@ -1,0 +1,232 @@
+import React, { useState, useEffect } from "react";
+import { ArrowLeftOutlined, NumberOutlined } from "@ant-design/icons";
+import { Button, Form, Input, Typography, Divider } from "antd";
+import { useLocation, useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
+import getBaseURL from "../utils/config";
+import { useUserContext } from "./UserContext";
+import CryptoJS from "crypto-js";
+
+const { Title } = Typography;
+
+const VerifyOTP = () => {
+  const baseURL = getBaseURL();
+  const [otpForm] = Form.useForm();
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isResending, setIsResending] = useState(false);
+  const [cooldown, setCooldown] = useState(60);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setAuth } = useUserContext();
+
+  // Retrieve user details from Register page
+  const userData = location.state || {};
+  const { name, phoneNumber, email, password } = userData; // Extract user data
+
+  useEffect(() => {
+    if (!email || !password) {
+      toast.error("No user data found, please register again.");
+      navigate("/register");
+    } else {
+      startCooldown(); // Start cooldown on page load
+    }
+  }, [email, password, navigate]);
+
+  // Start OTP cooldown timer
+  const startCooldown = () => {
+    let time = 60;
+    setCooldown(time);
+    const interval = setInterval(() => {
+      time -= 1;
+      setCooldown(time);
+      if (time === 0) {
+        clearInterval(interval);
+      }
+    }, 1000);
+  };
+
+  // Resend OTP
+  const onResendOTP = async () => {
+    if (cooldown > 0) {
+      toast.error(`Please wait ${cooldown} seconds before resending OTP.`);
+      return;
+    }
+
+    setIsResending(true);
+    try {
+      const response = await fetch(`${baseURL}/auth/send-otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      const parseRes = await response.json();
+      if (response.ok) {
+        toast.success(parseRes.message || "OTP resent successfully!");
+        startCooldown();
+      } else {
+        throw new Error(parseRes.message || "Failed to resend OTP.");
+      }
+    } catch (error) {
+      toast.error("Failed to resend OTP. Please try again.");
+    } finally {
+      setIsResending(false);
+    }
+  };
+
+  // Verify OTP & Register User
+  const onVerify = async (values) => {
+    setIsVerifying(true);
+    try {
+      const otp = values.otp;
+
+      // Step 1: Verify OTP
+      const verifyResponse = await fetch(`${baseURL}/auth/verify-otp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, otp }),
+      });
+
+      const verifyRes = await verifyResponse.json();
+
+      if (!verifyResponse.ok) {
+        throw new Error(verifyRes.message || "Failed to verify OTP.");
+      }
+
+      toast.success("OTP verified successfully! Registering your account...");
+
+      // Step 2: Register the User
+      const encryptedPassword = CryptoJS.SHA256(password).toString(
+        CryptoJS.enc.Hex
+      );
+
+      const registerResponse = await fetch(`${baseURL}/auth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          phoneNumber,
+          email,
+          password: encryptedPassword,
+        }),
+      });
+
+      const registerRes = await registerResponse.json();
+
+      if (!registerResponse.ok || !registerRes.token) {
+        throw new Error(registerRes.message || "Failed to register user.");
+      }
+
+      // Step 3: Store token & log in the user
+      localStorage.setItem("token", registerRes.token);
+      setAuth(true); // Update authentication state
+
+      toast.success("Registration successful! Redirecting...");
+
+      // Step 4: Redirect to dashboard
+      navigate("/login");
+    } catch (error) {
+      toast.error(error.message || "An error occurred.");
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <section
+      style={{
+        padding: "0 140px",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <div
+        style={{
+          padding: "30px 40px",
+          borderRadius: "10px",
+          maxWidth: "600px",
+          margin: "50px auto",
+          boxShadow: "0 6px 20px rgba(0, 0, 0, 0.1)",
+          background: "#ffffff",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "15px",
+          position: "relative",
+        }}
+      >
+        {/* Back Button */}
+        <Button
+          type="text"
+          icon={<ArrowLeftOutlined />}
+          style={{
+            position: "absolute",
+            top: "10px",
+            left: "10px",
+            fontSize: "16px",
+          }}
+          onClick={() => navigate("/register")}
+        >
+          Back
+        </Button>
+
+        <Title level={3} style={{ textAlign: "center" }}>
+          Verify OTP
+        </Title>
+
+        <Divider>Enter the OTP sent to your email</Divider>
+
+        <Form
+          name="verify-otp"
+          form={otpForm}
+          className="verify-otp-form"
+          style={{ maxWidth: "100%", margin: "0 auto", width: "290px" }}
+          onFinish={onVerify}
+        >
+          <Form.Item
+            name="otp"
+            rules={[
+              { required: true, message: "Please enter the OTP!" },
+              { pattern: /^\d{6}$/, message: "OTP must be 6 digits." },
+            ]}
+          >
+            <Input
+              prefix={<NumberOutlined />}
+              placeholder="Enter OTP"
+              size="large"
+            />
+          </Form.Item>
+
+          {/* Resend OTP Button (same style as Verify, starts disabled) */}
+          <Form.Item>
+            <Button
+              type="primary"
+              onClick={onResendOTP}
+              disabled={cooldown > 0 || isResending}
+              loading={isResending}
+              style={{ width: "100%" }}
+            >
+              {cooldown > 0 ? `Resend OTP in ${cooldown}s` : "Resend OTP"}
+            </Button>
+          </Form.Item>
+
+          <Form.Item>
+            <Button
+              type="primary"
+              htmlType="submit"
+              className="verify-button"
+              style={{ width: "100%" }}
+              loading={isVerifying}
+              disabled={isVerifying}
+            >
+              Verify & Register
+            </Button>
+          </Form.Item>
+        </Form>
+      </div>
+    </section>
+  );
+};
+
+export default VerifyOTP;

--- a/client/src/router/index.js
+++ b/client/src/router/index.js
@@ -8,6 +8,7 @@ import Classes from "../components/Classes";
 import Pricing from "../components/Pricing";
 import Login from "../components/Login";
 import Register from "../components/Register";
+import VerifyOTP from "../components/VerifyOTP";
 import { useUserContext } from "../components/UserContext";
 import Class from "../components/Classes/Class";
 import AuthenticatedRoute from "./AuthenticatedRoute";
@@ -121,6 +122,7 @@ export default () => {
               )
             }
           ></Route>
+          <Route path="/verify-otp" element={<VerifyOTP />} />
         </Route>
 
         {/*******************


### PR DESCRIPTION
## ✨ What does this PR do?
- Implements a two-page registration flow with OTP verification.

## 🔨 Changes made
- Refactored the registration process into two steps:
  1. **Register Page**: Users enter their name, email, phone, and password.
  2. **OTP Verification Page**: Users input a 6-digit OTP sent via email.

## 🧪 How to test
1. Go to `/register` and enter user details.
2. Click "Next" → You should be redirected to `/verify-otp`.
3. Enter a **valid OTP** → Registration should complete successfully.
4. Try entering an **invalid OTP** → An error message should appear.
5. After entering a **correct OTP**:
   - The system should **auto-register the user**.
   - The user should be **automatically logged in**.
   - The system should **redirect to `/profile`**.

## 📸 Screenshots
![image](https://github.com/user-attachments/assets/0d4334a2-eca3-4b9e-a87e-224aa37befce)
![image](https://github.com/user-attachments/assets/c7e745f0-6fcb-410d-9814-6cc87ed47ecc)
