### PR TITLE
feat(partner): add endpoints for password reset via email and OTP flow

### DIFF
--- a/server/database.sql
+++ b/server/database.sql
@@ -201,6 +201,14 @@ INSERT INTO ageGroups (name, min_age, max_age)
     ('preschooler', 3, 6),
     ('above-7', 7, null);
 
+CREATE TABLE partnerPasswordResets (
+    reset_id SERIAL PRIMARY KEY,
+    partner_id UUID REFERENCES partners(partner_id) ON DELETE CASCADE,
+    token VARCHAR(255) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
 -- ADMIN PORTAL
 CREATE TABLE admins (
     admin_id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),


### PR DESCRIPTION
## ✨ What does this PR do?
Adds backend support for the vendor password reset flow via email and OTP.

---

## 🔨 Changes made
- Added `POST /partners/check-email`
  - Validates if a given partner email exists in the database
  - Returns 404 if not found
- Added `POST /partners/reset-password`
  - Hashes the new password using bcrypt
  - Updates the password in the database
  - Returns 404 if the partner email does not exist

---

## 🧪 How to test
1. `POST /partners/check-email`
   - Send a known/unknown email
   - Expect 200 for known, 404 for unknown
2. `POST /partners/reset-password`
   - Send a known email + new password
   - Expect 200 for success, 404 if email not found
   - Confirm password is hashed in DB

Both endpoints are used by the vendor portal password reset flow:
- `/partners/check-email` is called at the start of the reset flow.
- `/partners/reset-password` is called after OTP is verified and a new password is submitted.
